### PR TITLE
open_access_doc.md5sum is required

### DIFF
--- a/gdcdictionary/schemas/open_access_doc.yaml
+++ b/gdcdictionary/schemas/open_access_doc.yaml
@@ -32,6 +32,7 @@ required:
   - submitter_id
   - file_name
   - file_size
+  - md5sum
   - data_format
   - doc_url
 


### PR DESCRIPTION

### Improvements
- Node "open_access_doc" prop "md5sum" is now required
