### PR TITLE
Accept any data_format

### DIFF
--- a/gdcdictionary/schemas/clinical_trial_file.yaml
+++ b/gdcdictionary/schemas/clinical_trial_file.yaml
@@ -63,26 +63,7 @@ properties:
   data_format:
     term:
       $ref: "_terms.yaml#/data_format"
-    enum:
-      - FASTA
-      - FAI
-      - ALT
-      - BWT
-      - PAC
-      - ANN
-      - AMB
-      - SA
-      - TAR
-      - VCF
-      - BCF
-      - TBI
-      - GDS
-      - TXT
-      - RDATA
-      - AVRO
-      - CSV
-      - TSV
-      - PDF
+    type: string
 
   core_metadata_collections:
     $ref: "_definitions.yaml#/to_one"

--- a/gdcdictionary/schemas/open_access_doc.yaml
+++ b/gdcdictionary/schemas/open_access_doc.yaml
@@ -59,26 +59,7 @@ properties:
   data_format:
     term:
       $ref: "_terms.yaml#/data_format"
-    enum:
-      - FASTA
-      - FAI
-      - ALT
-      - BWT
-      - PAC
-      - ANN
-      - AMB
-      - SA
-      - TAR
-      - VCF
-      - BCF
-      - TBI
-      - GDS
-      - TXT
-      - RDATA
-      - AVRO
-      - CSV
-      - TSV
-      - PDF
+    type: string
 
   doc_url:
    description: >


### PR DESCRIPTION


### Improvements
- "clinical_trial_file" and "open_access_doc" accept any "data_format" instead of enums
